### PR TITLE
feat: Building 기능 완성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ out/
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
+
+
+### ADMIN ###
+/src/main/java/com/koreatech/hangill/controller/BuildingManagingController.java

--- a/src/main/java/com/koreatech/hangill/HangillApplication.java
+++ b/src/main/java/com/koreatech/hangill/HangillApplication.java
@@ -2,8 +2,9 @@ package com.koreatech.hangill;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class HangillApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/koreatech/hangill/controller/BuildingController.java
+++ b/src/main/java/com/koreatech/hangill/controller/BuildingController.java
@@ -1,0 +1,63 @@
+package com.koreatech.hangill.controller;
+
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.domain.NodeType;
+import com.koreatech.hangill.dto.NodeDto;
+import com.koreatech.hangill.dto.request.ShortestPathRequest;
+import com.koreatech.hangill.dto.response.ShortestPathResponse;
+import com.koreatech.hangill.service.BuildingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class BuildingController {
+    private final BuildingService buildingService;
+
+    @GetMapping("/api/v1/building/nodes/{buildingId}/{nodeType}")
+    public ResponseEntity<Map<String, Object>> findNodesByType(
+            @PathVariable Long buildingId, @PathVariable NodeType nodeType) {
+        Map<String, Object> resultMap = new HashMap<>();
+        try {
+            List<Node> nodes = buildingService.findAllNodesByType(buildingId, nodeType);
+            List<NodeDto> nodeDtos = nodes.stream()
+                    .map(NodeDto::new)
+                    .toList();
+            resultMap.put("nodes", nodeDtos);
+            resultMap.put("message", "SUCCESS!");
+            return new ResponseEntity<>(resultMap, HttpStatus.OK);
+        } catch (Exception e) {
+            resultMap.put("message", "ERROR!");
+            resultMap.put("errorMessage", e.getMessage());
+            return new ResponseEntity<>(resultMap, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @GetMapping("/api/v1/building/path/{buildingId}/{startNodeId}/{endNodeId}")
+    public ResponseEntity<Map<String, Object>> findPath(
+            @PathVariable Long buildingId,
+            @PathVariable Long startNodeId,
+            @PathVariable Long endNodeId) {
+        Map<String, Object> resultMap = new HashMap<>();
+        try {
+            ShortestPathResponse path = buildingService.findPath(
+                    new ShortestPathRequest(buildingId, startNodeId, endNodeId)
+            );
+            resultMap.put("path", path);
+            resultMap.put("message", "SUCCESS!");
+            return new ResponseEntity<>(resultMap, HttpStatus.OK);
+        } catch (Exception e) {
+            resultMap.put("message", "ERROR!");
+            resultMap.put("errorMessage", e.getMessage());
+            return new ResponseEntity<>(resultMap, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/koreatech/hangill/domain/Edge.java
+++ b/src/main/java/com/koreatech/hangill/domain/Edge.java
@@ -3,23 +3,25 @@ package com.koreatech.hangill.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
 public class Edge {
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue
     @Column(name = "edge_id")
     private Long id;
 
     // mm단위
     private Long distance;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY, cascade = PERSIST)
     @JoinColumn(name = "start_node_id")
     private Node startNode;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY, cascade = PERSIST)
     @JoinColumn(name = "end_node_id")
     private Node endNode;
 
@@ -39,5 +41,13 @@ public class Edge {
     // 연관 관계 편의 메소드
     public void changeBuilding(Building building) {
         this.building = building;
+    }
+
+    public Double getDistanceToM() {
+        return distance / (double)1000;
+    }
+
+    public Double getDistanceToKM() {
+        return distance / (double)1_000_000;
     }
 }

--- a/src/main/java/com/koreatech/hangill/domain/Node.java
+++ b/src/main/java/com/koreatech/hangill/domain/Node.java
@@ -1,7 +1,10 @@
 package com.koreatech.hangill.domain;
 
+import com.koreatech.hangill.dto.request.CreateNodeRequest;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -10,9 +13,19 @@ import static jakarta.persistence.FetchType.LAZY;
  * 추후 Setter 제공하지 않게끔 수정 필요
  */
 @Entity
-@Getter @Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Node {
-    @Id @GeneratedValue
+    public Node(CreateNodeRequest request) {
+        this.number = request.getNumber();
+        this.name = request.getName();
+        this.description = request.getDescription();
+        this.type = request.getType();
+        this.floor = request.getFloor();
+    }
+
+    @Id
+    @GeneratedValue
     @Column(name = "node_id")
     private Long id;
 

--- a/src/main/java/com/koreatech/hangill/domain/NodeType.java
+++ b/src/main/java/com/koreatech/hangill/domain/NodeType.java
@@ -2,8 +2,12 @@ package com.koreatech.hangill.domain;
 
 public enum NodeType {
     ENTRANCE, // 입구
+
     STAIR, // 계단
     ROAD, // 복도
     ROOM, // 방
-    ELEVATOR // 엘리베이터
+
+    ELEVATOR, // 엘리베이터
+
+    DOOR // 문
 }

--- a/src/main/java/com/koreatech/hangill/dto/NodeDto.java
+++ b/src/main/java/com/koreatech/hangill/dto/NodeDto.java
@@ -1,0 +1,20 @@
+package com.koreatech.hangill.dto;
+
+import com.koreatech.hangill.domain.Node;
+import lombok.Data;
+
+@Data
+public class NodeDto {
+    public NodeDto(Node node) {
+        this.id = node.getId();
+        this.number = node.getNumber();
+        this.floor = node.getFloor();
+        this.name = node.getName();
+        this.description = node.getDescription();
+    }
+    private Long id;
+    private Integer number;
+    private Integer floor;
+    private String name;
+    private String description;
+}

--- a/src/main/java/com/koreatech/hangill/dto/NodeSearch.java
+++ b/src/main/java/com/koreatech/hangill/dto/NodeSearch.java
@@ -1,0 +1,12 @@
+package com.koreatech.hangill.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NodeSearch {
+    private Long buildingId;
+    private Integer number;
+    private Integer floor;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/AddEdgeToBuildingRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/AddEdgeToBuildingRequest.java
@@ -1,0 +1,15 @@
+package com.koreatech.hangill.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AddEdgeToBuildingRequest {
+    private Long buildingId;
+    private Integer startNodeNumber;
+    private Integer startNodeFloor;
+    private Integer endNodeNumber;
+    private Integer endNodeFloor;
+    private Long distance;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/AddNodeToBuildingRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/AddNodeToBuildingRequest.java
@@ -1,0 +1,16 @@
+package com.koreatech.hangill.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+
+@Data
+@AllArgsConstructor
+public class AddNodeToBuildingRequest {
+
+    @NotNull(message = "반드시 건물 id 입력")
+    private Long buildingId;
+    private CreateNodeRequest node;
+
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/CreateBuildingRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/CreateBuildingRequest.java
@@ -1,0 +1,19 @@
+package com.koreatech.hangill.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateBuildingRequest {
+    @NotEmpty(message = "건물 이름을 반드시 입력해주세요")
+    private String name;
+    private String description;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/CreateNodeRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/CreateNodeRequest.java
@@ -1,0 +1,22 @@
+package com.koreatech.hangill.dto.request;
+
+import com.koreatech.hangill.domain.NodeType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CreateNodeRequest {
+    @NotNull(message = "노드 번호를 반드시 입력.")
+    private Integer number;
+
+    private String name;
+
+    private String description;
+
+    private NodeType type;
+
+    @NotNull(message = "노드가 속한 층 수를 반드시 입력.")
+    private Integer floor;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/DeleteEdgeRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/DeleteEdgeRequest.java
@@ -1,0 +1,16 @@
+package com.koreatech.hangill.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DeleteEdgeRequest {
+    @NotNull(message = "반드시 건물 id 입력")
+    private Long buildingId;
+    private Integer startNodeNumber;
+    private Integer startNodeFloor;
+    private Integer endNodeNumber;
+    private Integer endNodeFloor;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/DeleteNodeRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/DeleteNodeRequest.java
@@ -1,0 +1,9 @@
+package com.koreatech.hangill.dto.request;
+
+import lombok.Data;
+
+@Data
+public class DeleteNodeRequest {
+    private Long buildingId;
+    private Long nodeId;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/ShortestPathRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/ShortestPathRequest.java
@@ -1,0 +1,12 @@
+package com.koreatech.hangill.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ShortestPathRequest {
+    private Long buildingId;
+    private Long startNodeId;
+    private Long endNodeId;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/BuildingResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/BuildingResponse.java
@@ -1,0 +1,22 @@
+package com.koreatech.hangill.dto.response;
+
+import com.koreatech.hangill.domain.Building;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class BuildingResponse {
+    public BuildingResponse(Building building) {
+        this.id = building.getId();
+        this.name = building.getName();
+        this.description = building.getDescription();
+        this.latitude = building.getLatitude();
+        this.longitude = building.getLongitude();
+    }
+    private Long id;
+    private String name;
+    private String description;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/EdgeResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/EdgeResponse.java
@@ -1,0 +1,17 @@
+package com.koreatech.hangill.dto.response;
+
+import com.koreatech.hangill.domain.Edge;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+public class EdgeResponse {
+    public EdgeResponse(Edge edge) {
+        this.startNode = new NodeResponse(edge.getStartNode());
+        this.endNode = new NodeResponse(edge.getEndNode());
+        this.distance = edge.getDistance();
+    }
+    private NodeResponse startNode;
+    private NodeResponse endNode;
+    private Long distance;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/NodeResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/NodeResponse.java
@@ -1,0 +1,19 @@
+package com.koreatech.hangill.dto.response;
+
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.domain.NodeType;
+import lombok.Data;
+
+@Data
+public class NodeResponse {
+    public NodeResponse(Node node) {
+        this.id = node.getId();
+        this.number = node.getNumber();
+        this.floor = node.getFloor();
+        this.type = node.getType();
+    }
+    private Long id;
+    private Integer number;
+    private Integer floor;
+    private NodeType type;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/ShortestPathResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/ShortestPathResponse.java
@@ -1,0 +1,22 @@
+package com.koreatech.hangill.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@AllArgsConstructor
+public class ShortestPathResponse {
+    public ShortestPathResponse(Long totalDistance, String path) {
+        this.path = Stream.of(path.split(" "))
+                .mapToLong(Long::parseLong)
+                .boxed()
+                .collect(Collectors.toList());
+        this.totalDistance = totalDistance;
+    }
+    private Long totalDistance;
+    private List<Long> path;
+}

--- a/src/main/java/com/koreatech/hangill/exception/CannotDeleteNodeException.java
+++ b/src/main/java/com/koreatech/hangill/exception/CannotDeleteNodeException.java
@@ -1,0 +1,23 @@
+package com.koreatech.hangill.exception;
+
+public class CannotDeleteNodeException extends RuntimeException{
+    public CannotDeleteNodeException() {
+
+    }
+
+    public CannotDeleteNodeException(String message) {
+        super(message);
+    }
+
+    public CannotDeleteNodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CannotDeleteNodeException(Throwable cause) {
+        super(cause);
+    }
+
+    protected CannotDeleteNodeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/koreatech/hangill/exception/CannotDeleteNodeException.java
+++ b/src/main/java/com/koreatech/hangill/exception/CannotDeleteNodeException.java
@@ -1,6 +1,6 @@
 package com.koreatech.hangill.exception;
 
-public class CannotDeleteNodeException extends RuntimeException{
+public class CannotDeleteNodeException extends RuntimeException {
     public CannotDeleteNodeException() {
 
     }

--- a/src/main/java/com/koreatech/hangill/exception/NoSuchNodeException.java
+++ b/src/main/java/com/koreatech/hangill/exception/NoSuchNodeException.java
@@ -1,0 +1,22 @@
+package com.koreatech.hangill.exception;
+
+public class NoSuchNodeException extends RuntimeException{
+    public NoSuchNodeException(String s) {
+        super(s);
+    }
+    public NoSuchNodeException() {
+        super();
+    }
+
+    public NoSuchNodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoSuchNodeException(Throwable cause) {
+        super(cause);
+    }
+
+    protected NoSuchNodeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/koreatech/hangill/repository/BuildingRepository.java
+++ b/src/main/java/com/koreatech/hangill/repository/BuildingRepository.java
@@ -1,0 +1,49 @@
+package com.koreatech.hangill.repository;
+
+import com.koreatech.hangill.domain.Building;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BuildingRepository {
+    private final EntityManager em;
+
+    public void save(Building building) {
+        em.persist(building);
+    }
+
+    public Building findOne(Long id) {
+        return em.find(Building.class, id);
+    }
+
+    public void deleteOne(Building building) {
+        em.remove(building);
+    }
+
+    public List<Building> findAll(String name) {
+        String query = """
+                SELECT b
+                FROM Building b
+                WHERE b.name = :name
+                """;
+
+        return em.createQuery(query, Building.class)
+                .setParameter("name", name)
+                .getResultList();
+    }
+
+    public List<Building> findAll() {
+        String query = """
+                SELECT b
+                FROM Building b
+                """;
+        return em.createQuery(query, Building.class)
+                .getResultList();
+    }
+
+
+}

--- a/src/main/java/com/koreatech/hangill/repository/EdgeRepository.java
+++ b/src/main/java/com/koreatech/hangill/repository/EdgeRepository.java
@@ -1,0 +1,60 @@
+package com.koreatech.hangill.repository;
+
+import com.koreatech.hangill.domain.Edge;
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.dto.request.DeleteEdgeRequest;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class EdgeRepository {
+    private final EntityManager em;
+
+    public void save(Edge edge) {
+        em.persist(edge);
+    }
+
+    public Edge findOne(Long id) {return em.find(Edge.class, id);}
+
+    public List<Edge> findAll(DeleteEdgeRequest request) {
+        String query = """
+                SELECT e
+                FROM Edge e JOIN e.building b
+                                ON b.id = :buildingId
+                            JOIN e.startNode sn
+                                ON sn.number = :startNodeNumber
+                                AND sn.floor = :startNodeFloor
+                            JOIN e.endNode en
+                                ON en.number = :endNodeNumber
+                                AND en.floor = :endNodeFloor
+                            
+                """;
+
+        return em.createQuery(query, Edge.class)
+                .setParameter("buildingId", request.getBuildingId())
+                .setParameter("startNodeNumber", request.getStartNodeNumber())
+                .setParameter("startNodeFloor", request.getStartNodeFloor())
+                .setParameter("endNodeNumber", request.getEndNodeNumber())
+                .setParameter("endNodeFloor", request.getEndNodeFloor())
+                .getResultList();
+    }
+
+    public List<Edge> findAll(Long buildingId) {
+        String query = """
+                SELECT e
+                FROM Edge e JOIN FETCH e.building b
+                            JOIN FETCH e.startNode sn
+                            JOIN FETCH e.endNode en
+                WHERE b.id = :buildingId
+                """;
+
+        return em.createQuery(query, Edge.class)
+                .setParameter("buildingId", buildingId)
+                .getResultList();
+    }
+
+}

--- a/src/main/java/com/koreatech/hangill/repository/NodeRepository.java
+++ b/src/main/java/com/koreatech/hangill/repository/NodeRepository.java
@@ -1,0 +1,65 @@
+package com.koreatech.hangill.repository;
+
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.dto.NodeSearch;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NodeRepository {
+    private final EntityManager em;
+
+    public void save(Node node) {
+        em.persist(node);
+    }
+
+    public List<Node> findAllByBuilding(Long buildingId) {
+        String query = """
+                SELECT n
+                FROM Node n JOIN n.building b
+                        ON b.id = :buildingId
+                """;
+        return em.createQuery(query, Node.class)
+                .setParameter("buildingId", buildingId)
+                .getResultList();
+    }
+
+    public List<Node> findAll(NodeSearch nodeSearch) {
+        String query = """
+                SELECT n
+                FROM Node n JOIN n.building b
+                        ON b.id = :buildingId
+                        AND n.number = :number
+                        AND n.floor = :floor   
+                """;
+        return em.createQuery(query, Node.class)
+                .setParameter("buildingId", nodeSearch.getBuildingId())
+                .setParameter("number", nodeSearch.getNumber())
+                .setParameter("floor", nodeSearch.getFloor())
+                .getResultList();
+    }
+    public Node findOne(NodeSearch nodeSearch) {
+    String query = """
+            SELECT n
+            FROM Node n JOIN n.building b
+                    ON b.id = :buildingId
+                    AND n.number = :number
+                    AND n.floor = :floor 
+            """;
+    return em.createQuery(query, Node.class)
+            .setParameter("buildingId", nodeSearch.getBuildingId())
+            .setParameter("number", nodeSearch.getNumber())
+            .setParameter("floor", nodeSearch.getFloor())
+            .getSingleResult();
+    }
+
+    public Node findOne(Long id) {
+        return em.find(Node.class, id);
+    }
+
+
+}

--- a/src/main/java/com/koreatech/hangill/service/BuildingManagingService.java
+++ b/src/main/java/com/koreatech/hangill/service/BuildingManagingService.java
@@ -15,4 +15,6 @@ public interface BuildingManagingService {
 
     void deleteEdge(Long buildingId, Long edgeId);
     void deleteNode(Long buildingId, Long nodeId);
+
+    void deleteBuilding(Long buildingId);
 }

--- a/src/main/java/com/koreatech/hangill/service/BuildingManagingService.java
+++ b/src/main/java/com/koreatech/hangill/service/BuildingManagingService.java
@@ -1,0 +1,18 @@
+package com.koreatech.hangill.service;
+
+import com.koreatech.hangill.dto.request.AddEdgeToBuildingRequest;
+import com.koreatech.hangill.dto.request.AddNodeToBuildingRequest;
+import com.koreatech.hangill.dto.request.CreateBuildingRequest;
+
+import java.util.List;
+import java.util.Map;
+
+public interface BuildingManagingService {
+    Long saveBuilding(CreateBuildingRequest request);
+    void addNode(AddNodeToBuildingRequest request);
+    void addEdge(AddEdgeToBuildingRequest request);
+    Map<Long, List<Long[]>> findNumberGraph(Long id);
+
+    void deleteEdge(Long buildingId, Long edgeId);
+    void deleteNode(Long buildingId, Long nodeId);
+}

--- a/src/main/java/com/koreatech/hangill/service/BuildingService.java
+++ b/src/main/java/com/koreatech/hangill/service/BuildingService.java
@@ -1,0 +1,18 @@
+package com.koreatech.hangill.service;
+
+import com.koreatech.hangill.domain.Edge;
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.domain.NodeType;
+import com.koreatech.hangill.dto.request.ShortestPathRequest;
+import com.koreatech.hangill.dto.response.ShortestPathResponse;
+
+import java.util.List;
+import java.util.Map;
+
+public interface BuildingService {
+    List<Node> findAllNodes(Long id);
+    List<Edge> findAllEdges(Long id);
+    List<Node> findAllNodesByType(Long id, NodeType type);
+    Map<Long, List<Long[]>> findIdGraph(Long id);
+    ShortestPathResponse findPath(ShortestPathRequest request);
+}

--- a/src/main/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImpl.java
@@ -119,6 +119,12 @@ public class BuildingManagingServiceImpl implements BuildingManagingService {
         building.getNodes().remove(node);
     }
 
+    public void deleteBuilding(Long buildingId) {
+        Building building = buildingRepository.findOne(buildingId);
+        buildingRepository.deleteOne(building);
+    }
+
+
 
 
     /**

--- a/src/main/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImpl.java
@@ -1,0 +1,153 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.domain.Building;
+import com.koreatech.hangill.domain.Edge;
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.dto.NodeSearch;
+import com.koreatech.hangill.dto.request.*;
+import com.koreatech.hangill.exception.CannotDeleteNodeException;
+import com.koreatech.hangill.repository.BuildingRepository;
+import com.koreatech.hangill.repository.EdgeRepository;
+import com.koreatech.hangill.repository.NodeRepository;
+import com.koreatech.hangill.service.BuildingManagingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 건물 데이터 삽입시 사용하는 Service
+ */
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BuildingManagingServiceImpl implements BuildingManagingService {
+    private final BuildingRepository buildingRepository;
+    private final NodeServiceImpl nodeService;
+    private final EdgeRepository edgeRepository;
+
+    private final NodeRepository nodeRepository;
+
+    /**
+     * 건물을 저장
+     * @param request : 건물 id, 건물 이름, 건물 설명, 건물 위도, 경도
+     * @return 저장한 건물 id
+     */
+    @Override
+    public Long saveBuilding(CreateBuildingRequest request) {
+        Building building = new Building(request);
+        validateDuplicatedBuilding(building.getName());
+        buildingRepository.save(building);
+        log.info("{}", building.getDescription());
+        return building.getId();
+    }
+
+    /**
+     * 동일 이름의 건물이 있는지 검증하는 로직
+     */
+    public void validateDuplicatedBuilding(String name) {
+        if (buildingRepository.findAll(name).size() > 0) throw new IllegalStateException("같은 이름의 건물이 있습니다.");
+    }
+
+    /**
+     * 건물에 노드 추가
+     * @param request : 건물 id, 추가할 노드 정보
+     */
+
+    @Override
+    public void addNode(AddNodeToBuildingRequest request) {
+        Building building = buildingRepository.findOne(request.getBuildingId());
+        nodeService.validateDuplicatedNode(
+                new NodeSearch(
+                        building.getId(),
+                        request.getNode().getNumber(),
+                        request.getNode().getFloor())
+        );
+        Node node = new Node(request.getNode());
+        building.addNode(node);
+    }
+
+    /**
+     * 건물에 엣지 추가
+     * @param request : 건물 id, 추가할 엣지 정보(출발 노드 번호, 출발 노드 층, 도착 노드 번호, 도착 노드 층)
+     */
+    @Override
+    public void addEdge(AddEdgeToBuildingRequest request) {
+        Building building = buildingRepository.findOne(request.getBuildingId());
+        // 먼저 연결할 Node 를 영속화해야함.
+        Node startNode = nodeService.findOne(new NodeSearch(
+                building.getId(),
+                request.getStartNodeNumber(),
+                request.getStartNodeFloor()
+        ));
+
+        Node endNode = nodeService.findOne(new NodeSearch(
+                building.getId(),
+                request.getEndNodeNumber(),
+                request.getEndNodeFloor()
+        ));
+        building.addEdge(Edge.createEdge(startNode, endNode, request.getDistance()));
+    }
+
+    public void deleteEdge(Long buildingId, Long edgeId) {
+        Building building = buildingRepository.findOne(buildingId);
+        building.getEdges().remove(edgeRepository.findOne(edgeId));
+    }
+
+    public void deleteNode(Long buildingId, Long nodeId) {
+        List<Edge> edges = edgeRepository.findAll(buildingId);
+        for (Edge edge : edges) {
+            if (edge.getStartNode().getId().equals(nodeId)) {
+                throw new CannotDeleteNodeException(
+                        edge.getStartNode().getNumber() + "번 노드를 출발 노드로 하는 엣지가 있기에 해당 노드를 삭제할 수 없음."
+                );
+            }
+            if (edge.getEndNode().getId().equals(nodeId)) {
+                throw new CannotDeleteNodeException(
+                        edge.getEndNode().getNumber() + "번 노드를 도착 노드로 하는 엣지가 있기에 해당 노드를 삭제할 수 없음."
+                );
+            }
+        }
+        Building building = buildingRepository.findOne(buildingId);
+        Node node = nodeRepository.findOne(nodeId);
+        building.getNodes().remove(node);
+    }
+
+
+
+    /**
+     * 건물의 노드 번호로 구성된 그래프 반환.
+     * @param id : 건물 id
+     */
+    public Map<Long, List<Long[]>> findNumberGraph(Long id) {
+
+        Building building = buildingRepository.findOne(id);
+        List<Node> nodes = building.getNodes();
+        List<Edge> edges = edgeRepository.findAll(id);
+
+        Map<Long, List<Long[]>> graph = new HashMap<>();
+        for (Node node : nodes) {
+            graph.put(Long.valueOf(node.getNumber()), new ArrayList<>());
+        }
+        for (Edge edge : edges) {
+            Long start = Long.valueOf(edge.getStartNode().getNumber());
+            Long end = Long.valueOf(edge.getEndNode().getNumber());
+            Long weight = edge.getDistance();
+            graph.get(start).add(new Long[]{end, weight});
+        }
+        return graph;
+    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/koreatech/hangill/service/impl/BuildingServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/BuildingServiceImpl.java
@@ -1,0 +1,124 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.domain.Building;
+import com.koreatech.hangill.domain.Edge;
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.domain.NodeType;
+import com.koreatech.hangill.dto.request.ShortestPathRequest;
+import com.koreatech.hangill.dto.response.ShortestPathResponse;
+import com.koreatech.hangill.repository.BuildingRepository;
+import com.koreatech.hangill.repository.EdgeRepository;
+import com.koreatech.hangill.service.BuildingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BuildingServiceImpl implements BuildingService {
+
+    private final BuildingRepository buildingRepository;
+    private final EdgeRepository edgeRepository;
+
+
+    /**
+     * 건물에 해당하는 모든 노드 조회
+     * @param id : 건물 id
+     */
+    public List<Node> findAllNodes(Long id) {
+        return buildingRepository.findOne(id).getNodes();
+    }
+
+    public List<Edge> findAllEdges(Long id) {
+        return edgeRepository.findAll(id);
+    }
+
+    /**
+     * 건물의 노드 목록을 노드 타입을 통해 얻기
+     * @param id : 건물 id
+     * @param type : 조회할 노드 타입
+     */
+    public List<Node> findAllNodesByType(Long id, NodeType type) {
+        Building building = buildingRepository.findOne(id);
+        return building.getNodes().stream()
+                .filter(node -> node.getType() == type)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 건물의 노드 id로 구성된 Graph를 반환
+     * @param id 건물 id
+     */
+    public Map<Long, List<Long[]>> findIdGraph(Long id) {
+        Building building = buildingRepository.findOne(id);
+        List<Node> nodes = building.getNodes();
+        List<Edge> edges = edgeRepository.findAll(id);
+
+        Map<Long, List<Long[]>> graph = new HashMap<>();
+        for (Node node : nodes) {
+            graph.put(node.getId(), new ArrayList<>());
+        }
+        for (Edge edge : edges) {
+            Long start = edge.getStartNode().getId();
+            Long end = edge.getEndNode().getId();
+            Long weight = edge.getDistance();
+            graph.get(start).add(new Long[]{end, weight});
+        }
+        return graph;
+    }
+
+
+    /**
+     * 최단 경로 알고리즘.
+     * @param request : 건물 id, 출발 노드 id, 도착 노드 id
+     * @return 최단 경로와 거리를 담은 객체
+     */
+    public ShortestPathResponse findPath(ShortestPathRequest request) {
+        Long INF = Long.MAX_VALUE;
+        List<Node> nodes = buildingRepository.findOne(request.getBuildingId()).getNodes();
+        Map<Long, Long> distance = new HashMap<>();
+        Map<Long, Long> path = new HashMap<>();
+        for (Node node : nodes) {
+            distance.put(node.getId(), INF);
+        }
+        Map<Long, List<Long[]>> graph = findIdGraph(request.getBuildingId());
+
+        distance.put(request.getStartNodeId(), 0L);
+        Queue<Long[]> queue = new PriorityQueue<>((a, b) -> Long.compare(a[1], b[1]));
+        queue.add(new Long[]{request.getStartNodeId(), 0L});
+
+        while (!queue.isEmpty()) {
+            Long[] minNode = queue.poll();
+            if (minNode[1] > distance.get(minNode[0])) continue;
+
+            for (Long[] edge : graph.get(minNode[0])) {
+                Long n_node = edge[0];
+                Long weight = edge[1];
+                if (distance.get(minNode[0]) + weight < distance.get(n_node)) {
+                    distance.put(n_node, distance.get(minNode[0]) + weight);
+                    queue.add(new Long[]{n_node, distance.get(n_node)});
+                    path.put(n_node, minNode[0]);
+                }
+            }
+        }
+
+
+        return new ShortestPathResponse(
+                distance.get(request.getEndNodeId()),
+                findPath(request.getStartNodeId(), request.getEndNodeId(), path)
+        );
+    }
+
+
+    private String findPath(Long start, Long node, Map<Long, Long> path) {
+        if (node.equals(start)) return start + "";
+        return findPath(start, path.get(node), path) + " " + node;
+    }
+
+
+
+}

--- a/src/main/java/com/koreatech/hangill/service/impl/EdgeServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/EdgeServiceImpl.java
@@ -1,0 +1,15 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.repository.EdgeRepository;
+import com.koreatech.hangill.repository.NodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EdgeServiceImpl {
+    private final EdgeRepository edgeRepository;
+    private final NodeRepository nodeRepository;
+}

--- a/src/main/java/com/koreatech/hangill/service/impl/NodeServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/NodeServiceImpl.java
@@ -1,0 +1,76 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.domain.Building;
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.dto.NodeSearch;
+import com.koreatech.hangill.dto.request.AddNodeToBuildingRequest;
+import com.koreatech.hangill.exception.NoSuchNodeException;
+import com.koreatech.hangill.repository.BuildingRepository;
+import com.koreatech.hangill.repository.NodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NodeServiceImpl {
+    private final NodeRepository nodeRepository;
+    private final BuildingRepository buildingRepository;
+
+    /**
+     * 건물에 노드 추가
+     * @param request : 건물 ID, 노드 정보
+     * @return 저장한 노드 ID
+     */
+    public Long addNodeToBuilding(AddNodeToBuildingRequest request) {
+        Building building = buildingRepository.findOne(request.getBuildingId());
+        // 중복 노드 검증.
+        validateDuplicatedNode(
+                new NodeSearch(
+                        request.getBuildingId(),
+                        request.getNode().getNumber(),
+                        request.getNode().getFloor()
+                )
+        );
+
+        Node node = new Node(request.getNode());
+        node.changeBuilding(building);
+        nodeRepository.save(node);
+        return node.getId();
+    }
+
+    /**
+     * 중복 노드 검증
+     * @param nodeSearch : 건물 ID, 층, 번호
+     */
+
+    @Transactional(readOnly = true)
+    public void validateDuplicatedNode(NodeSearch nodeSearch) {
+        if (nodeRepository.findAll(nodeSearch).size() > 0) throw new IllegalStateException("같은 건물의 같은 층에 해당 번호의 노드가 존재합니다.");
+    }
+
+    /**
+     * 노드가 있는지 검증
+     * @param nodeSearch : 건물 ID, 층, 번호
+     */
+    @Transactional(readOnly = true)
+    public void validateHasNode(NodeSearch nodeSearch) {
+        if (nodeRepository.findAll(nodeSearch).size() == 0) throw new NoSuchNodeException("해당 노드가 없습니다!");
+    }
+
+    /**
+     * 조건을 통해 노드 한개 조회
+     * @param nodeSearch : 건물 Id, 층, 번호
+     * @return 노드
+     */
+    public Node findOne(NodeSearch nodeSearch) {
+        try {
+            return nodeRepository.findOne(nodeSearch);
+        }catch (Exception e) {
+            throw new NoSuchNodeException("건물에 헤당 노드가 없습니다!");
+        }
+    }
+
+
+}

--- a/src/test/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImplTest.java
@@ -1,0 +1,229 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.domain.Building;
+import com.koreatech.hangill.domain.Edge;
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.domain.NodeType;
+import com.koreatech.hangill.dto.request.AddEdgeToBuildingRequest;
+import com.koreatech.hangill.dto.request.AddNodeToBuildingRequest;
+import com.koreatech.hangill.dto.request.CreateBuildingRequest;
+import com.koreatech.hangill.dto.request.CreateNodeRequest;
+import com.koreatech.hangill.exception.NoSuchNodeException;
+import com.koreatech.hangill.repository.BuildingRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@SpringBootTest
+@Transactional
+class BuildingManagingServiceImplTest {
+
+    @Autowired
+    BuildingManagingServiceImpl buildingService;
+    @Autowired
+    BuildingRepository buildingRepository;
+
+    @Autowired
+    BuildingManagingServiceImpl buildingManagingService;
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    public void 건물에서_노드_추가() throws Exception {
+        //given
+        Long buildingId = saveBuilding();
+
+
+        CreateNodeRequest createNodeRequest = new CreateNodeRequest(1, null, null, null, 1);
+        CreateNodeRequest createNodeRequest2 = new CreateNodeRequest(2, null, null, null, 1);
+        CreateNodeRequest createNodeRequest3 = new CreateNodeRequest(3, null, null, null, 1);
+
+
+        //when
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                createNodeRequest
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                createNodeRequest2
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                createNodeRequest3
+        ));
+
+        em.flush();
+        em.clear();
+        //then
+        // 테스트 결과 컬렉션의 요소 하나에 대해 데이터 요청만해도 모든 요소들의 Proxy가 초기화됨.
+        System.out.println("===================================");
+        Building building = buildingRepository.findOne(buildingId);
+        System.out.println(building.getNodes().get(0).getNumber());
+        System.out.println(building.getNodes().get(0).getClass());
+        System.out.println(building.getNodes().get(1).getClass());
+        System.out.println(building.getNodes().get(2).getClass());
+
+        List<Node> rooms = building.getNodes().stream()
+                .filter(node -> node.getType() == NodeType.ROOM).toList();
+
+    }
+
+    @Test
+    public void 건물_엣지_추가() throws Exception {
+        //given
+        Long buildingId = saveBuilding();
+
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                new CreateNodeRequest(1, null, null, null, 3)
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                new CreateNodeRequest(2, null, null, null, 3)
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                new CreateNodeRequest(3, null, null, null, 3)
+        ));
+
+        //when
+        buildingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId,
+                1, 3, 3, 3, 100L
+        ));
+        buildingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId,
+                2, 3, 3, 3, 100L
+        ));
+        buildingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId,
+                2, 3, 1, 3, 100L
+        ));
+
+        //then
+
+        em.flush();
+        em.clear();
+
+        Building building = buildingRepository.findOne(buildingId);
+        for (Edge edge : building.getEdges()) {
+            System.out.println(edge.getDistance());
+            System.out.println(edge.getStartNode().getNumber() + "->" + edge.getEndNode().getNumber());
+        }
+
+        building.getNodes().remove(0);
+
+    }
+
+    private Long saveBuilding() {
+        Long buildingId = buildingService.saveBuilding(
+                new CreateBuildingRequest("공학 2관", "컴공", null, null)
+        );
+        return buildingId;
+    }
+
+    @Test
+    public void 엣지_예외_테스트() throws Exception {
+        //given
+        Long buildingId = buildGraph("공학 1관");
+
+        Assertions.assertThrows(NoSuchNodeException.class, () -> {
+            buildingManagingService.addEdge(
+                    new AddEdgeToBuildingRequest(
+                            buildingId, 1, 1, 6, 3, 100L)
+
+            );
+        });
+        //when
+
+        //then
+
+
+    }
+
+    private Long buildGraph(String buildingName) {
+        Long buildingId = buildingManagingService.saveBuilding(new CreateBuildingRequest(
+                buildingName,
+                "컴공", null, null
+        ));
+
+
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                1, null, null, NodeType.ENTRANCE, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                2, null, null, NodeType.ROOM, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                3, null, null, NodeType.ROAD, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                4, null, null, NodeType.ROAD, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                5, null, null, NodeType.ROOM, 1
+                        )
+                )
+        );
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 2, 1, 2L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 3, 1, 3L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 4, 1, 1L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 5, 1, 10L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 2, 1, 4, 1, 2L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 3, 1, 4, 1, 1L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 3, 1, 5, 1, 1L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 4, 1, 5, 1, 3L
+        ));
+
+        return buildingId;
+    }
+
+
+}

--- a/src/test/java/com/koreatech/hangill/service/impl/BuildingServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/BuildingServiceImplTest.java
@@ -1,0 +1,206 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.domain.Building;
+import com.koreatech.hangill.domain.Edge;
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.domain.NodeType;
+import com.koreatech.hangill.dto.NodeSearch;
+import com.koreatech.hangill.dto.request.*;
+import com.koreatech.hangill.dto.response.ShortestPathResponse;
+import com.koreatech.hangill.repository.BuildingRepository;
+import com.koreatech.hangill.repository.EdgeRepository;
+import com.koreatech.hangill.repository.NodeRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+//@Rollback(value = false)
+class BuildingServiceImplTest {
+
+    @Autowired
+    BuildingManagingServiceImpl buildingManagingService;
+    @Autowired
+    BuildingRepository buildingRepository;
+    @Autowired
+    BuildingServiceImpl buildingService;
+    @Autowired
+    NodeRepository nodeRepository;
+
+    @Autowired
+    EdgeRepository edgeRepository;
+
+
+    @Test
+    public void 모든_노드_조회() throws Exception {
+        //given
+        Long buildingId = buildGraph();
+        //when
+        List<Node> nodes = buildingService.findAllNodes(buildingId);
+        //then
+
+        List<Node> nodes2 = nodeRepository.findAllByBuilding(buildingId);
+        assertEquals(nodes2, nodes);
+    }
+
+
+    @Test
+    public void 모든_엣지_조회() throws Exception {
+        //given
+        Long buildingId = buildGraph();
+        Building building = buildingRepository.findOne(buildingId);
+        //when
+
+        //then
+        for (Edge edge : building.getEdges()) {
+            System.out.println(edge.getStartNode().getNumber() + "--(" + edge.getDistance() + ")->" + edge.getEndNode().getNumber());
+        }
+        System.out.println("====================");
+        for (Edge edge : edgeRepository.findAll(buildingId)) {
+            System.out.println(edge.getStartNode().getNumber() + "--(" + edge.getDistance() + ")->" + edge.getEndNode().getNumber());
+        }
+
+    }
+
+    @Test
+    public void 그래프_조회() throws Exception {
+        //given
+        Long buildingId = buildGraph();
+
+        //when
+        Map<Long, List<Long[]>> numberGraph = buildingManagingService.findNumberGraph(buildingId);
+        //then
+
+        System.out.println(numberGraph.toString());
+    }
+
+    @Test
+    public void 최단_경로_조회() throws Exception {
+        //given
+        Long buildingId = buildGraph();
+        Node startNode = nodeRepository.findOne(new NodeSearch(
+                buildingId, 1, 1)
+        );
+        Node endNode = nodeRepository.findOne(new NodeSearch(
+                buildingId, 5, 1)
+        );
+        Node node = nodeRepository.findOne(new NodeSearch(
+                buildingId, 4, 1
+        ));
+
+        //when
+        ShortestPathResponse shortestPathResponse = buildingService.dijkstra(new ShortestPathRequest(
+                buildingId,
+                startNode.getId(), endNode.getId()
+        ));
+        List<Long> pathLabel = new ArrayList<>();
+        pathLabel.add(startNode.getId());
+        pathLabel.add(node.getId());
+        pathLabel.add(endNode.getId());
+
+        //then
+        assertEquals(pathLabel, shortestPathResponse.getPath());
+        assertEquals(4, shortestPathResponse.getTotalDistance());
+
+    }
+
+    @Test
+    public void 강의실_조회_테스트() throws Exception{
+        //given
+        Long buildingId = buildGraph();
+
+        //when
+        List<Node> allNodesByType = buildingService.findAllNodesByType(buildingId, NodeType.ROOM);
+
+        //then
+        for (Node node : allNodesByType) {
+            assertEquals(NodeType.ROOM, node.getType());
+        }
+
+     }
+
+    private Long buildGraph() {
+        Long buildingId = buildingManagingService.saveBuilding(new CreateBuildingRequest(
+                "공학2관",
+                "컴공", null, null
+        ));
+
+
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                1, null, null, NodeType.ENTRANCE, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                2, null, null, NodeType.ROOM, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                3, null, null, NodeType.ROAD, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                4, null, null, NodeType.ROAD, 1
+                        )
+                )
+        );
+        buildingManagingService.addNode(
+                new AddNodeToBuildingRequest(
+                        buildingId,
+                        new CreateNodeRequest(
+                                5, null, null, NodeType.ROOM, 1
+                        )
+                )
+        );
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 2, 1, 2L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 3, 1, 3L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 4, 1, 1L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 1, 1, 5, 1, 10L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 2, 1, 4, 1, 2L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 3, 1, 4, 1, 1L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 3, 1, 5, 1, 1L
+        ));
+        buildingManagingService.addEdge(new AddEdgeToBuildingRequest(
+                buildingId, 4, 1, 5, 1, 3L
+        ));
+
+        return buildingId;
+    }
+
+}

--- a/src/test/java/com/koreatech/hangill/service/impl/NodeServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/NodeServiceImplTest.java
@@ -1,0 +1,42 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.dto.request.AddNodeToBuildingRequest;
+import com.koreatech.hangill.dto.request.CreateBuildingRequest;
+import com.koreatech.hangill.dto.request.CreateNodeRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class NodeServiceImplTest {
+    @Autowired
+    BuildingManagingServiceImpl buildingService;
+    @Autowired
+    NodeServiceImpl nodeService;
+    @Test
+    public void 건물에_노드_추가() throws Exception {
+        //given
+        Long buildingId = buildingService.saveBuilding(
+                new CreateBuildingRequest("공학 2관", "컴공", null, null)
+        );
+
+        CreateNodeRequest createNodeRequest = new CreateNodeRequest(1, null, null, null, 1);
+        CreateNodeRequest createNodeRequest2 = new CreateNodeRequest(2, null, null, null, 1);
+        CreateNodeRequest createNodeRequest3 = new CreateNodeRequest(3, null, null, null, 1);
+
+
+        //when
+        nodeService.addNodeToBuilding(new AddNodeToBuildingRequest(buildingId, createNodeRequest));
+        nodeService.addNodeToBuilding(new AddNodeToBuildingRequest(buildingId, createNodeRequest2));
+        nodeService.addNodeToBuilding(new AddNodeToBuildingRequest(buildingId, createNodeRequest3));
+
+        //then
+
+
+    }
+}


### PR DESCRIPTION
## 구현 기능
- HanGill Building 관리 기능 구현
- HanGill Building 기능 구현

## Building 관리 기능
- 데이터 수정을 위한 다음 기능들을 추가
  - Building 추가 기능
  - Building에 Node 추가 / 삭제 기능
  - Building에 Edge 추가 / 삭제 기능
  - Building에 추가한 Node 목록 조회 기능
  - Building에 추가한 Edge 목록 조회 기능
  - Building의 Graph 조회 기능
  - building 삭제 기능 추가
 
## Building 기능
- Front-End에서 실제로 API 요청하여 사용할 다음 기능들을 추가
  - Building에 속한 Node 목록을 타입 별로 조회(강의실, 복도, 계단 ...etc)
  - Building 내부에서 최단 경로 조회(출발 Node, 도착 Node까지의 최단 경로)

## 새롭게 알게된 사실
- Fetch Join에서 ON 절은 일관성을 해치지 않는 범위에서만 사용해야 한다.
- orpanRemoval=true 옵션으로 고아 객체가 된 Entity를 자동으로 제거할 수 있다.
- @NotEmpty Validation 어노테이션은 다음 타입에 지원된다.
  - CharSequence : 문자열의 길이가 0이거나 문자열이 null이면 위반
  - Collection : Collection Size가 0이거나 Collection이 null이면 위반
  - Map : Map Size가 0이거나 Map이 null이면 위반
  - Array : Array Size가 0이거나 Array가 null이면 위반
