### PR TITLE
feat : AccessPoint 관리 기능 추가, 노드에 Fingerprint 관리 기능 추가, Swagger 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ out/
 
 ### ADMIN ###
 /src/main/java/com/koreatech/hangill/controller/BuildingManagingController.java
+/src/main/java/com/koreatech/hangill/controller/AccessPointManagingController.java

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ out/
 /src/main/java/com/koreatech/hangill/controller/BuildingManagingController.java
 /src/main/java/com/koreatech/hangill/controller/AccessPointManagingController.java
 /src/main/java/com/koreatech/hangill/controller/NodeManagingController.java
+/src/main/java/com/koreatech/hangill/controller/swagger/AccessPointManagingApi.java
+/src/main/java/com/koreatech/hangill/controller/swagger/BuildingManagingApi.java
+/src/main/java/com/koreatech/hangill/controller/swagger/NodeManagingApi.java
+

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ out/
 ### ADMIN ###
 /src/main/java/com/koreatech/hangill/controller/BuildingManagingController.java
 /src/main/java/com/koreatech/hangill/controller/AccessPointManagingController.java
+/src/main/java/com/koreatech/hangill/controller/NodeManagingController.java

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/koreatech/hangill/config/SwaggerConfig.java
+++ b/src/main/java/com/koreatech/hangill/config/SwaggerConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
         info = @Info(
                 title = "HanGill API 명세서",
-                description = "API for HanGill App.",
+                description = "API Docs for HanGill App.",
                 version = "v1"
         )
 )

--- a/src/main/java/com/koreatech/hangill/config/SwaggerConfig.java
+++ b/src/main/java/com/koreatech/hangill/config/SwaggerConfig.java
@@ -1,0 +1,16 @@
+package com.koreatech.hangill.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "HanGill API 명세서",
+                description = "API for HanGill App.",
+                version = "v1"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+}

--- a/src/main/java/com/koreatech/hangill/controller/AccessPointController.java
+++ b/src/main/java/com/koreatech/hangill/controller/AccessPointController.java
@@ -1,0 +1,14 @@
+package com.koreatech.hangill.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class AccessPointController {
+
+}

--- a/src/main/java/com/koreatech/hangill/controller/BuildingController.java
+++ b/src/main/java/com/koreatech/hangill/controller/BuildingController.java
@@ -4,18 +4,16 @@ import com.koreatech.hangill.domain.Node;
 import com.koreatech.hangill.domain.NodeType;
 import com.koreatech.hangill.dto.NodeDto;
 import com.koreatech.hangill.dto.request.ShortestPathRequest;
+import com.koreatech.hangill.dto.response.NodeDtosResponse;
 import com.koreatech.hangill.dto.response.ShortestPathResponse;
 import com.koreatech.hangill.service.BuildingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,41 +21,24 @@ public class BuildingController {
     private final BuildingService buildingService;
 
     @GetMapping("/api/v1/building/nodes/{buildingId}/{nodeType}")
-    public ResponseEntity<Map<String, Object>> findNodesByType(
+    public ResponseEntity<NodeDtosResponse> findNodesByType(
             @PathVariable Long buildingId, @PathVariable NodeType nodeType) {
-        Map<String, Object> resultMap = new HashMap<>();
-        try {
             List<Node> nodes = buildingService.findAllNodesByType(buildingId, nodeType);
             List<NodeDto> nodeDtos = nodes.stream()
                     .map(NodeDto::new)
                     .toList();
-            resultMap.put("nodes", nodeDtos);
-            resultMap.put("message", "SUCCESS!");
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            resultMap.put("message", "ERROR!");
-            resultMap.put("errorMessage", e.getMessage());
-            return new ResponseEntity<>(resultMap, HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+            return ResponseEntity.ok().body(new NodeDtosResponse(nodeDtos));
     }
 
     @GetMapping("/api/v1/building/path/{buildingId}/{startNodeId}/{endNodeId}")
-    public ResponseEntity<Map<String, Object>> findPath(
+    public ResponseEntity<ShortestPathResponse> findPath(
             @PathVariable Long buildingId,
             @PathVariable Long startNodeId,
             @PathVariable Long endNodeId) {
-        Map<String, Object> resultMap = new HashMap<>();
-        try {
             ShortestPathResponse path = buildingService.findPath(
                     new ShortestPathRequest(buildingId, startNodeId, endNodeId)
             );
-            resultMap.put("path", path);
-            resultMap.put("message", "SUCCESS!");
-            return new ResponseEntity<>(resultMap, HttpStatus.OK);
-        } catch (Exception e) {
-            resultMap.put("message", "ERROR!");
-            resultMap.put("errorMessage", e.getMessage());
-            return new ResponseEntity<>(resultMap, HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+            return ResponseEntity.ok().body(path);
+
     }
 }

--- a/src/main/java/com/koreatech/hangill/controller/BuildingController.java
+++ b/src/main/java/com/koreatech/hangill/controller/BuildingController.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.controller;
 
+import com.koreatech.hangill.controller.swagger.BuildingApi;
 import com.koreatech.hangill.domain.Node;
 import com.koreatech.hangill.domain.NodeType;
 import com.koreatech.hangill.dto.NodeDto;
@@ -17,7 +18,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-public class BuildingController {
+public class BuildingController implements BuildingApi {
     private final BuildingService buildingService;
 
     @GetMapping("/api/v1/building/nodes/{buildingId}/{nodeType}")

--- a/src/main/java/com/koreatech/hangill/controller/NodeController.java
+++ b/src/main/java/com/koreatech/hangill/controller/NodeController.java
@@ -1,0 +1,9 @@
+package com.koreatech.hangill.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NodeController {
+}

--- a/src/main/java/com/koreatech/hangill/controller/swagger/AccessPointApi.java
+++ b/src/main/java/com/koreatech/hangill/controller/swagger/AccessPointApi.java
@@ -1,0 +1,4 @@
+package com.koreatech.hangill.controller.swagger;
+
+public interface AccessPointApi {
+}

--- a/src/main/java/com/koreatech/hangill/controller/swagger/BuildingApi.java
+++ b/src/main/java/com/koreatech/hangill/controller/swagger/BuildingApi.java
@@ -1,0 +1,4 @@
+package com.koreatech.hangill.controller.swagger;
+
+public interface BuildingApi {
+}

--- a/src/main/java/com/koreatech/hangill/controller/swagger/BuildingApi.java
+++ b/src/main/java/com/koreatech/hangill/controller/swagger/BuildingApi.java
@@ -1,4 +1,32 @@
 package com.koreatech.hangill.controller.swagger;
 
+import com.koreatech.hangill.domain.NodeType;
+import com.koreatech.hangill.dto.response.NodeDtosResponse;
+import com.koreatech.hangill.dto.response.ShortestPathResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "건물 관련 API", description = "건물의 노드 목록 조회, 건물의 경로 조회 API")
 public interface BuildingApi {
+    @Operation(summary = "건물 노드 목록 조회(타입별) API")
+    @ApiResponses(
+            @ApiResponse(responseCode = "200", description = "건물 노드 목록 조회 성공")
+    )
+    @GetMapping("/api/v1/building/nodes/{buildingId}/{nodeType}")
+    ResponseEntity<NodeDtosResponse> findNodesByType(
+            @PathVariable Long buildingId, @PathVariable NodeType nodeType);
+    @Operation(summary = "건물에서 경로 조회 API")
+    @ApiResponses(
+            @ApiResponse(responseCode = "200", description = "건물에서 경로 조회 성공")
+    )
+    @GetMapping("/api/v1/building/path/{buildingId}/{startNodeId}/{endNodeId}")
+    ResponseEntity<ShortestPathResponse> findPath(
+            @PathVariable Long buildingId,
+            @PathVariable Long startNodeId,
+            @PathVariable Long endNodeId);
 }

--- a/src/main/java/com/koreatech/hangill/controller/swagger/NodeApi.java
+++ b/src/main/java/com/koreatech/hangill/controller/swagger/NodeApi.java
@@ -1,0 +1,4 @@
+package com.koreatech.hangill.controller.swagger;
+
+public interface NodeApi {
+}

--- a/src/main/java/com/koreatech/hangill/domain/AccessPoint.java
+++ b/src/main/java/com/koreatech/hangill/domain/AccessPoint.java
@@ -1,0 +1,44 @@
+package com.koreatech.hangill.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.koreatech.hangill.domain.OperationStatus.*;
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.FetchType.*;
+import static lombok.AccessLevel.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class AccessPoint {
+    public AccessPoint(String ssid, String mac, Building building) {
+        this.ssid = ssid;
+        this.mac = mac;
+        this.building = building;
+        turnOn();
+    }
+    @Id @GeneratedValue
+    @Column(name = "access_point_id")
+    private Long id;
+
+    private String ssid;
+
+    private String mac;
+
+    @Enumerated(STRING)
+    private OperationStatus status;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "building_id")
+    private Building building;
+
+
+    public void turnOff() {
+        this.status = STOP;
+    }
+    public void turnOn() {
+        this.status = RUNNING;
+    }
+}

--- a/src/main/java/com/koreatech/hangill/domain/AccessPoint.java
+++ b/src/main/java/com/koreatech/hangill/domain/AccessPoint.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import static com.koreatech.hangill.domain.OperationStatus.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
 @Entity
@@ -19,7 +20,7 @@ public class AccessPoint {
         this.building = building;
         turnOn();
     }
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "access_point_id")
     private Long id;
 

--- a/src/main/java/com/koreatech/hangill/domain/Building.java
+++ b/src/main/java/com/koreatech/hangill/domain/Building.java
@@ -23,9 +23,15 @@ public class Building {
         this.latitude = request.getLatitude();
         this.longitude = request.getLongitude();
     }
+    // Entity 생성이 복잡하지 않다면 DTO로 초기화하는 것보다 그냥 멤버 변수 나열하는게 좋아보임. => 테스트 간편!
+    public Building(String name, String description, BigDecimal latitude, BigDecimal longitude) {
+        this.name = name;
+        this.description = description;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue
     @Column(name = "building_id")
     private Long id;
 
@@ -41,7 +47,6 @@ public class Building {
 
     @OneToMany(mappedBy = "building", cascade = ALL, orphanRemoval = true)
     private List<Node> nodes = new ArrayList<>();
-
 
     /**
      * 이거 조회시 사용할 경우 쿼리 너무 많이 나감. 성능 생각해서 조회시 사용하지 말자
@@ -59,7 +64,6 @@ public class Building {
         edge.changeBuilding(this);
         this.edges.add(edge);
     }
-
 
 
 }

--- a/src/main/java/com/koreatech/hangill/domain/Building.java
+++ b/src/main/java/com/koreatech/hangill/domain/Building.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.GenerationType.*;
 
 @Entity
 @Getter
@@ -31,7 +32,7 @@ public class Building {
         this.longitude = longitude;
     }
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "building_id")
     private Long id;
 

--- a/src/main/java/com/koreatech/hangill/domain/Edge.java
+++ b/src/main/java/com/koreatech/hangill/domain/Edge.java
@@ -5,11 +5,12 @@ import lombok.Getter;
 
 import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.*;
 
 @Entity
 @Getter
 public class Edge {
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "edge_id")
     private Long id;
 

--- a/src/main/java/com/koreatech/hangill/domain/Edge.java
+++ b/src/main/java/com/koreatech/hangill/domain/Edge.java
@@ -9,8 +9,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @Entity
 @Getter
 public class Edge {
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue
     @Column(name = "edge_id")
     private Long id;
 

--- a/src/main/java/com/koreatech/hangill/domain/Fingerprint.java
+++ b/src/main/java/com/koreatech/hangill/domain/Fingerprint.java
@@ -1,0 +1,43 @@
+package com.koreatech.hangill.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.*;
+import static lombok.AccessLevel.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Fingerprint {
+    public Fingerprint(AccessPoint accessPoint, Integer rssi, LocalDateTime measurementDate) {
+        changeAccessPoint(accessPoint);
+        this.rssi = rssi;
+        this.measurementDate = measurementDate;
+    }
+    @Id @GeneratedValue
+    @Column(name = "fingerprint_id")
+    private Long id;
+
+    private Integer rssi;
+    private LocalDateTime measurementDate;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "node_id")
+    private Node node;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "access_point_id")
+    private AccessPoint accessPoint;
+
+    public void changeNode(Node node) {
+        this.node = node;
+    }
+    public void changeAccessPoint(AccessPoint accessPoint) {
+        this.accessPoint = accessPoint;
+    }
+
+}

--- a/src/main/java/com/koreatech/hangill/domain/Fingerprint.java
+++ b/src/main/java/com/koreatech/hangill/domain/Fingerprint.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
 @Entity
@@ -18,7 +19,7 @@ public class Fingerprint {
         this.rssi = rssi;
         this.measurementDate = measurementDate;
     }
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "fingerprint_id")
     private Long id;
 

--- a/src/main/java/com/koreatech/hangill/domain/Node.java
+++ b/src/main/java/com/koreatech/hangill/domain/Node.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.*;
 
 /**
  * 추후 Setter 제공하지 않게끔 수정 필요
@@ -36,7 +37,7 @@ public class Node {
         this.floor = floor;
     }
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "node_id")
     private Long id;
 

--- a/src/main/java/com/koreatech/hangill/domain/Node.java
+++ b/src/main/java/com/koreatech/hangill/domain/Node.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
 
 /**
@@ -16,6 +20,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Node {
+    // Entity 초기화가 복잡하지 않다면 DTO로 받는 것보단 멤버 변수를 일일히 나열하는 편이 좋을 듯.
     public Node(CreateNodeRequest request) {
         this.number = request.getNumber();
         this.name = request.getName();
@@ -23,9 +28,15 @@ public class Node {
         this.type = request.getType();
         this.floor = request.getFloor();
     }
+    public Node(Integer number, String name, String description, NodeType type, Integer floor) {
+        this.number = number;
+        this.name = name;
+        this.description = description;
+        this.type = type;
+        this.floor = floor;
+    }
 
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue
     @Column(name = "node_id")
     private Long id;
 
@@ -44,7 +55,24 @@ public class Node {
     @JoinColumn(name = "building_id")
     private Building building;
 
+    @OneToMany(mappedBy = "node", cascade = ALL, orphanRemoval = true)
+    private List<Fingerprint> fingerprints = new ArrayList<>();
+
     public void changeBuilding(Building building) {
         this.building = building;
+    }
+
+    // 연관 관계 편의 메소드.
+    private void addFingerprint(Fingerprint fingerprint) {
+        this.fingerprints.add(fingerprint);
+        fingerprint.changeNode(this);
+    }
+
+    public void buildFingerprints(List<Fingerprint> fingerprints) {
+        // 기존의 Fingerprint 모두 제거 : clear()로 리스트를 비워주면 orphanRemoval 옵션으로 인해 연관 관계가 끊어진 Fingerprint Entity가 지워짐
+        this.fingerprints.clear();
+        for (Fingerprint fingerprint : fingerprints) {
+            addFingerprint(fingerprint);
+        }
     }
 }

--- a/src/main/java/com/koreatech/hangill/domain/NodeType.java
+++ b/src/main/java/com/koreatech/hangill/domain/NodeType.java
@@ -2,12 +2,9 @@ package com.koreatech.hangill.domain;
 
 public enum NodeType {
     ENTRANCE, // 입구
-
     STAIR, // 계단
     ROAD, // 복도
     ROOM, // 방
-
     ELEVATOR, // 엘리베이터
-
     DOOR // 문
 }

--- a/src/main/java/com/koreatech/hangill/domain/OperationStatus.java
+++ b/src/main/java/com/koreatech/hangill/domain/OperationStatus.java
@@ -1,0 +1,6 @@
+package com.koreatech.hangill.domain;
+
+public enum OperationStatus {
+    RUNNING,
+    STOP
+}

--- a/src/main/java/com/koreatech/hangill/dto/NodeDto.java
+++ b/src/main/java/com/koreatech/hangill/dto/NodeDto.java
@@ -1,6 +1,7 @@
 package com.koreatech.hangill.dto;
 
 import com.koreatech.hangill.domain.Node;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
@@ -12,9 +13,30 @@ public class NodeDto {
         this.name = node.getName();
         this.description = node.getDescription();
     }
+    @Schema(
+            description = "노드의 ID",
+            example = "1"
+    )
     private Long id;
+    @Schema(
+            description = "건물 지도상 노드의 번호",
+            example = "2"
+    )
     private Integer number;
+    @Schema(
+            description = "건물 내 노드의 층 수",
+            example = "3"
+    )
     private Integer floor;
+    @Schema(
+            description = "노드의 이름",
+            example = "319호"
+    )
     private String name;
+
+    @Schema(
+            description = "노드의 설명",
+            example = "XXX 교수님 연구실"
+    )
     private String description;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/AccessPointRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/AccessPointRequest.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -7,8 +8,25 @@ import lombok.Data;
 @Data
 public class AccessPointRequest {
     @NotNull(message = "건물ID 필수로 입력!")
+    @Schema(
+            description = "AP를 추가할 건물 ID",
+            nullable = false,
+            example = "1"
+    )
+
     private Long buildingId;
+    @Schema(
+            description = "추가할 AP의 SSID",
+            nullable = false,
+            example = "KOREATECH"
+    )
     private String ssid;
+
+    @Schema(
+            description = "추가할 AP의 MAC 주소",
+            nullable = false,
+            example = "4D:5C:22:F2:FF:2A"
+    )
     @NotEmpty(message = "mac 주소 필수로 입력!")
     private String mac;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/AccessPointRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/AccessPointRequest.java
@@ -1,0 +1,14 @@
+package com.koreatech.hangill.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class AccessPointRequest {
+    @NotNull(message = "건물ID 필수로 입력!")
+    private Long buildingId;
+    private String ssid;
+    @NotEmpty(message = "mac 주소 필수로 입력!")
+    private String mac;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/AddEdgeToBuildingRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/AddEdgeToBuildingRequest.java
@@ -1,15 +1,46 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class AddEdgeToBuildingRequest {
+    @Schema(
+            description = "간선을 추가할 건물 ID",
+            nullable = false,
+            example = "1"
+    )
     private Long buildingId;
+    @Schema(
+            description = "간선의 시작 노드 번호",
+            nullable = false,
+            example = "1"
+    )
     private Integer startNodeNumber;
+    @Schema(
+            description = "간선의 시작 노드의 층",
+            nullable = false,
+            example = "2"
+    )
     private Integer startNodeFloor;
+    @Schema(
+            description = "간선의 도착 노드 번호",
+            nullable = false,
+            example = "2"
+    )
     private Integer endNodeNumber;
+    @Schema(
+            description = "간선의 도착 노드 층",
+            nullable = false,
+            example = "1"
+    )
     private Integer endNodeFloor;
+    @Schema(
+            description = "간선의 거리",
+            nullable = false,
+            example = "1021"
+    )
     private Long distance;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/AddNodeToBuildingRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/AddNodeToBuildingRequest.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,7 +11,13 @@ import lombok.Data;
 public class AddNodeToBuildingRequest {
 
     @NotNull(message = "반드시 건물 id 입력")
+    @Schema(
+            description = "노드를 추가할 건물 ID",
+            nullable = false,
+            example = "1"
+    )
     private Long buildingId;
+
     private CreateNodeRequest node;
 
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/BuildFingerprintRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/BuildFingerprintRequest.java
@@ -1,0 +1,11 @@
+package com.koreatech.hangill.dto.request;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BuildFingerprintRequest {
+    private Long nodeId;
+    private List<SignalRequest> signals;
+}

--- a/src/main/java/com/koreatech/hangill/dto/request/BuildFingerprintRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/BuildFingerprintRequest.java
@@ -1,11 +1,25 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
 public class BuildFingerprintRequest {
+    @NotNull(message = "노드 ID 반드시 추가!")
+    @Schema(
+            description = "핑거프린트를 추가할 노드 ID",
+            nullable = false,
+            example = "1"
+    )
     private Long nodeId;
+
+    @Schema(
+            description = "노드에 추가할 wifi 신호들",
+            nullable = true,
+            extensions = {}
+    )
     private List<SignalRequest> signals;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/CreateBuildingRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/CreateBuildingRequest.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,8 +13,29 @@ import java.math.BigDecimal;
 @NoArgsConstructor
 public class CreateBuildingRequest {
     @NotEmpty(message = "건물 이름을 반드시 입력해주세요")
+    @Schema(
+            description = "추가할 건물의 이름",
+            nullable = false,
+            example = "2공학관"
+    )
     private String name;
+
+    @Schema(
+            description = "추가할 건물의 설명",
+            nullable = false,
+            example = "컴퓨터 공학부와 건축, 디자인 학생들이 전공 수업을 듣는 곳"
+    )
     private String description;
+    @Schema(
+            description = "추가할 건물의 위도",
+            nullable = true,
+            example = "37.4123"
+    )
     private BigDecimal latitude;
+    @Schema(
+            description = "추가할 건물의 경도",
+            nullable = true,
+            example = "127.5341"
+    )
     private BigDecimal longitude;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/CreateNodeRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/CreateNodeRequest.java
@@ -1,6 +1,7 @@
 package com.koreatech.hangill.dto.request;
 
 import com.koreatech.hangill.domain.NodeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -9,14 +10,39 @@ import lombok.Data;
 @AllArgsConstructor
 public class CreateNodeRequest {
     @NotNull(message = "노드 번호를 반드시 입력.")
+    @Schema(
+            description = "추가할 노드의 번호",
+            nullable = false,
+            example = "1"
+    )
     private Integer number;
 
+    @Schema(
+            description = "추가할 노드의 이름",
+            nullable = false,
+            example = "319호"
+    )
     private String name;
 
+    @Schema(
+            description = "추가할 노드의 세부 설명",
+            nullable = false,
+            example = "XXX 교수님의 연구실"
+    )
     private String description;
 
+    @Schema(
+            description = "추가할 노드의 타입",
+            nullable = false,
+            example = "ROOM"
+    )
     private NodeType type;
 
+    @Schema(
+            description = "추가할 노드의 층 수",
+            nullable = false,
+            example = "3"
+    )
     @NotNull(message = "노드가 속한 층 수를 반드시 입력.")
     private Integer floor;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/DeleteEdgeRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/DeleteEdgeRequest.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,9 +9,34 @@ import lombok.Data;
 @AllArgsConstructor
 public class DeleteEdgeRequest {
     @NotNull(message = "반드시 건물 id 입력")
+    @Schema(
+            description = "간선을 삭제할 건물 ID",
+            nullable = false,
+            example = "1"
+    )
     private Long buildingId;
+    @Schema(
+            description = "간선의 시작 노드 번호",
+            nullable = false,
+            example = "1"
+    )
     private Integer startNodeNumber;
+    @Schema(
+            description = "간선의 시작 노드의 층",
+            nullable = false,
+            example = "2"
+    )
     private Integer startNodeFloor;
+    @Schema(
+            description = "간선의 도착 노드 번호",
+            nullable = false,
+            example = "2"
+    )
     private Integer endNodeNumber;
+    @Schema(
+            description = "간선의 도착 노드 층",
+            nullable = false,
+            example = "1"
+    )
     private Integer endNodeFloor;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/DeleteNodeRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/DeleteNodeRequest.java
@@ -1,9 +1,16 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
 public class DeleteNodeRequest {
+    @Schema(
+            description = "삭제할 노드의 건물 ID",
+            example = "1"
+    )
     private Long buildingId;
+    @Schema(description = "삭제할 노드 ID", example = "1")
+
     private Long nodeId;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/ShortestPathRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/ShortestPathRequest.java
@@ -1,12 +1,25 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class ShortestPathRequest {
+    @Schema(
+            description = "경로를 조회할 건물 ID",
+            example = "1"
+    )
     private Long buildingId;
+    @Schema(
+            description = "경로의 시작 노드 ID",
+            example = "1"
+    )
     private Long startNodeId;
+    @Schema(
+            description = "경로의 도착 노드 ID",
+            example = "76"
+    )
     private Long endNodeId;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/SignalRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/SignalRequest.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,22 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SignalRequest {
+    @Schema(
+            description = "AP의 SSID",
+            nullable = true,
+            example = "KOREATECH"
+    )
     private String ssid;
+    @Schema(
+            description = "AP의 MAC 주소",
+            nullable = true,
+            example = "34:5D:AD:14:DB:20"
+    )
     private String mac;
+    @Schema(
+            description = "rssi값(AP의 신호세기)",
+            nullable = true,
+            example = "-46"
+    )
     private Integer rssi;
 }

--- a/src/main/java/com/koreatech/hangill/dto/request/SignalRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/SignalRequest.java
@@ -1,0 +1,14 @@
+package com.koreatech.hangill.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignalRequest {
+    private String ssid;
+    private String mac;
+    private Integer rssi;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/AccessPointResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/AccessPointResponse.java
@@ -1,6 +1,7 @@
 package com.koreatech.hangill.dto.response;
 
 import com.koreatech.hangill.domain.AccessPoint;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
@@ -10,6 +11,15 @@ public class AccessPointResponse {
         this.mac = accessPoint.getMac();
     }
 
+    @Schema(
+            description = "AP의 ssid",
+            example = "KOREATECH"
+    )
     private String ssid;
+    @Schema(
+            description = "AP의 mac주소",
+            nullable = true,
+            example = "4D:42:56:1A:2B:4C"
+    )
     private String mac;
 }

--- a/src/main/java/com/koreatech/hangill/dto/response/AccessPointResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/AccessPointResponse.java
@@ -1,0 +1,15 @@
+package com.koreatech.hangill.dto.response;
+
+import com.koreatech.hangill.domain.AccessPoint;
+import lombok.Data;
+
+@Data
+public class AccessPointResponse {
+    public AccessPointResponse(AccessPoint accessPoint) {
+        this.ssid = accessPoint.getSsid();
+        this.mac = accessPoint.getMac();
+    }
+
+    private String ssid;
+    private String mac;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/AccessPointsResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/AccessPointsResponse.java
@@ -1,0 +1,12 @@
+package com.koreatech.hangill.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class AccessPointsResponse {
+    private List<AccessPointResponse> accessPoints;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/BuildingResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/BuildingResponse.java
@@ -1,6 +1,7 @@
 package com.koreatech.hangill.dto.response;
 
 import com.koreatech.hangill.domain.Building;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -14,9 +15,33 @@ public class BuildingResponse {
         this.latitude = building.getLatitude();
         this.longitude = building.getLongitude();
     }
+    @Schema(
+            description = "건물 ID",
+            example = "1"
+    )
     private Long id;
+
+    @Schema(
+            description = "건물의 이름",
+            example = "공학 2관"
+    )
     private String name;
+
+    @Schema(
+            description = "건물의 세부 설명",
+            example = "컴퓨터 공학부 학생들과 건축, 디자인 공학부 학생들이 수업 듣는 공학관"
+    )
     private String description;
+
+    @Schema(
+            description = "건물의 위도",
+            example = "37.23212"
+    )
     private BigDecimal latitude;
+
+    @Schema(
+            description = "건물의 경도",
+            example = "127.23134"
+    )
     private BigDecimal longitude;
 }

--- a/src/main/java/com/koreatech/hangill/dto/response/BuildingsResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/BuildingsResponse.java
@@ -1,0 +1,12 @@
+package com.koreatech.hangill.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class BuildingsResponse {
+    private List<BuildingResponse> buildings;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/EdgeResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/EdgeResponse.java
@@ -1,16 +1,17 @@
 package com.koreatech.hangill.dto.response;
 
 import com.koreatech.hangill.domain.Edge;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 public class EdgeResponse {
     public EdgeResponse(Edge edge) {
+        this.edgeId = edge.getId();
         this.startNode = new NodeResponse(edge.getStartNode());
         this.endNode = new NodeResponse(edge.getEndNode());
         this.distance = edge.getDistance();
     }
+    private Long edgeId;
     private NodeResponse startNode;
     private NodeResponse endNode;
     private Long distance;

--- a/src/main/java/com/koreatech/hangill/dto/response/EdgeResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/EdgeResponse.java
@@ -1,6 +1,7 @@
 package com.koreatech.hangill.dto.response;
 
 import com.koreatech.hangill.domain.Edge;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
@@ -11,8 +12,26 @@ public class EdgeResponse {
         this.endNode = new NodeResponse(edge.getEndNode());
         this.distance = edge.getDistance();
     }
+
+    @Schema(
+            description = "간선의 ID",
+            example = "1"
+    )
     private Long edgeId;
+    @Schema(
+            description = "간선의 시작 노드"
+    )
     private NodeResponse startNode;
+    @Schema(
+            description = "간선의 도착 노드"
+
+    )
     private NodeResponse endNode;
+
+    @Schema(
+            description = "간선의 가중치(노드 사이의 거리(mm))",
+            example = "1023"
+
+    )
     private Long distance;
 }

--- a/src/main/java/com/koreatech/hangill/dto/response/EdgesResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/EdgesResponse.java
@@ -1,0 +1,12 @@
+package com.koreatech.hangill.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class EdgesResponse {
+    private List<EdgeResponse> edges;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/FingerprintResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/FingerprintResponse.java
@@ -1,0 +1,16 @@
+package com.koreatech.hangill.dto.response;
+
+import com.koreatech.hangill.domain.Fingerprint;
+import lombok.Data;
+
+@Data
+public class FingerprintResponse {
+    public FingerprintResponse(Fingerprint fingerprint) {
+        this.ssid = fingerprint.getAccessPoint().getSsid();
+        this.mac = fingerprint.getAccessPoint().getMac();
+        this.rssi = fingerprint.getRssi();
+    }
+    private String ssid;
+    private String mac;
+    private Integer rssi;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/FingerprintResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/FingerprintResponse.java
@@ -1,6 +1,7 @@
 package com.koreatech.hangill.dto.response;
 
 import com.koreatech.hangill.domain.Fingerprint;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
@@ -10,7 +11,24 @@ public class FingerprintResponse {
         this.mac = fingerprint.getAccessPoint().getMac();
         this.rssi = fingerprint.getRssi();
     }
+    @Schema(
+            description = "AP의 ssid",
+            nullable = true,
+            example = "KOREATECH"
+    )
     private String ssid;
+
+    @Schema(
+            description = "AP의 MAC 주소",
+            nullable = true,
+            example = "34:5D:AD:14:DB:20"
+    )
     private String mac;
+
+    @Schema(
+            description = "신호 세기",
+            nullable = true,
+            example = "-47"
+    )
     private Integer rssi;
 }

--- a/src/main/java/com/koreatech/hangill/dto/response/FingerprintsResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/FingerprintsResponse.java
@@ -1,0 +1,14 @@
+package com.koreatech.hangill.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class FingerprintsResponse {
+    @Schema(description = "핑거프린트 목록")
+    private List<FingerprintResponse> fingerprints;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/NodeDtosResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/NodeDtosResponse.java
@@ -1,0 +1,13 @@
+package com.koreatech.hangill.dto.response;
+
+import com.koreatech.hangill.dto.NodeDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class NodeDtosResponse {
+    private List<NodeDto> nodes;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/NodeResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/NodeResponse.java
@@ -2,6 +2,7 @@ package com.koreatech.hangill.dto.response;
 
 import com.koreatech.hangill.domain.Node;
 import com.koreatech.hangill.domain.NodeType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
@@ -12,8 +13,25 @@ public class NodeResponse {
         this.floor = node.getFloor();
         this.type = node.getType();
     }
+    @Schema(
+            description = "노드의 ID",
+            example = "1"
+    )
     private Long id;
+    @Schema(
+            description = "지도 상의 노드 번호",
+            example = "2"
+    )
     private Integer number;
+
+    @Schema(
+            description = "건물에서 노드의 층 수",
+            example = "1"
+    )
     private Integer floor;
+    @Schema(
+            description = "노드의 타입",
+            example = "ENTRANCE"
+    )
     private NodeType type;
 }

--- a/src/main/java/com/koreatech/hangill/dto/response/NodesResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/NodesResponse.java
@@ -1,0 +1,12 @@
+package com.koreatech.hangill.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class NodesResponse {
+    private List<NodeResponse> nodes;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/NumberGraphResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/NumberGraphResponse.java
@@ -1,0 +1,13 @@
+package com.koreatech.hangill.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+public class NumberGraphResponse {
+    private Map<Long, List<Long[]>> graph;
+}

--- a/src/main/java/com/koreatech/hangill/dto/response/NumberGraphResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/NumberGraphResponse.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,5 +10,37 @@ import java.util.Map;
 @Data
 @AllArgsConstructor
 public class NumberGraphResponse {
+    @Schema(
+            description = "건물의 그래프(노드 번호 기준)",
+            example = """
+                    {
+                        "graph": {
+                            "1": [
+                                [6, 3],
+                                [4, 3],
+                                [2, 3]
+                            ],
+                            "2": [
+                                [1, 3],
+                                [6, 3],
+                                [3, 3]
+                            ],
+                            "3": [
+                                [5, 3]
+                            ],
+                            "4": [
+                                [6, 3]
+                            ],
+                            "5": [
+                                [3, 3],
+                                [2, 3]
+                            ],
+                            "6": [
+                                [1, 3]
+                            ]
+                        }
+                    }
+                    """
+    )
     private Map<Long, List<Long[]>> graph;
 }

--- a/src/main/java/com/koreatech/hangill/dto/response/ShortestPathResponse.java
+++ b/src/main/java/com/koreatech/hangill/dto/response/ShortestPathResponse.java
@@ -1,5 +1,6 @@
 package com.koreatech.hangill.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -17,6 +18,14 @@ public class ShortestPathResponse {
                 .collect(Collectors.toList());
         this.totalDistance = totalDistance;
     }
+    @Schema(
+            description = "경로의 총 길이(mm)",
+            example = "1,000,320"
+    )
     private Long totalDistance;
+    @Schema(
+            description = "경로상에서 지나는 노드의 순서",
+            example = "[1, 2, 5, 4, 3]"
+    )
     private List<Long> path;
 }

--- a/src/main/java/com/koreatech/hangill/repository/AccessPointRepository.java
+++ b/src/main/java/com/koreatech/hangill/repository/AccessPointRepository.java
@@ -1,7 +1,6 @@
 package com.koreatech.hangill.repository;
 
 import com.koreatech.hangill.domain.AccessPoint;
-import com.koreatech.hangill.domain.Building;
 import com.koreatech.hangill.domain.OperationStatus;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -18,21 +17,42 @@ public class AccessPointRepository {
     public void save(AccessPoint accessPoint) {
         em.persist(accessPoint);
     }
+    public AccessPoint findOne(Long id) {return em.find(AccessPoint.class, id);}
 
-
+    /**
+     QueryDSL 학습 후 동적쿼리 작성으로 리펙토링 필요
+     */
     public List<AccessPoint> findAll(Long buildingId, String mac, OperationStatus running) {
         String query = """
                 SELECT a
                 FROM AccessPoint a
                 JOIN a.building b
                     ON b.id = :buildingId
-                WHERE a.mac = :mac
+                    AND  a.mac = :mac
                     AND a.status = :running
                 """;
         return em.createQuery(query, AccessPoint.class)
                 .setParameter("buildingId", buildingId)
                 .setParameter("mac", mac)
                 .setParameter("running", running)
+                .getResultList();
+    }
+
+    public List<AccessPoint> findAll(Long buildingId) {
+        String query = """
+                SELECT a
+                FROM AccessPoint a
+                JOIN a.building b
+                    ON b.id = :buildingId
+                """;
+        return em.createQuery(query, AccessPoint.class)
+                .setParameter("buildingId", buildingId)
+                .getResultList();
+    }
+
+    public List<AccessPoint> findAll(String mac) {
+        return em.createQuery("SELECT a FROM AccessPoint a WHERE a.mac = :mac", AccessPoint.class)
+                .setParameter("mac", mac)
                 .getResultList();
     }
 }

--- a/src/main/java/com/koreatech/hangill/repository/AccessPointRepository.java
+++ b/src/main/java/com/koreatech/hangill/repository/AccessPointRepository.java
@@ -1,0 +1,39 @@
+package com.koreatech.hangill.repository;
+
+import com.koreatech.hangill.domain.AccessPoint;
+import com.koreatech.hangill.domain.Building;
+import com.koreatech.hangill.domain.OperationStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+@RequiredArgsConstructor
+public class AccessPointRepository {
+    private final EntityManager em;
+
+    public void save(AccessPoint accessPoint) {
+        em.persist(accessPoint);
+    }
+
+
+    public List<AccessPoint> findAll(Long buildingId, String mac, OperationStatus running) {
+        String query = """
+                SELECT a
+                FROM AccessPoint a
+                JOIN a.building b
+                    ON b.id = :buildingId
+                WHERE a.mac = :mac
+                    AND a.status = :running
+                """;
+        return em.createQuery(query, AccessPoint.class)
+                .setParameter("buildingId", buildingId)
+                .setParameter("mac", mac)
+                .setParameter("running", running)
+                .getResultList();
+    }
+}
+

--- a/src/main/java/com/koreatech/hangill/repository/EdgeRepository.java
+++ b/src/main/java/com/koreatech/hangill/repository/EdgeRepository.java
@@ -1,7 +1,6 @@
 package com.koreatech.hangill.repository;
 
 import com.koreatech.hangill.domain.Edge;
-import com.koreatech.hangill.domain.Node;
 import com.koreatech.hangill.dto.request.DeleteEdgeRequest;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/koreatech/hangill/repository/FingerprintRepository.java
+++ b/src/main/java/com/koreatech/hangill/repository/FingerprintRepository.java
@@ -1,0 +1,16 @@
+package com.koreatech.hangill.repository;
+
+import com.koreatech.hangill.domain.Fingerprint;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FingerprintRepository {
+    private final EntityManager em;
+
+    public void save(Fingerprint fingerprint) {
+        em.persist(fingerprint);
+    }
+}

--- a/src/main/java/com/koreatech/hangill/service/AccessPointService.java
+++ b/src/main/java/com/koreatech/hangill/service/AccessPointService.java
@@ -1,4 +1,8 @@
 package com.koreatech.hangill.service;
 
+import com.koreatech.hangill.domain.AccessPoint;
+import com.koreatech.hangill.dto.request.AccessPointRequest;
+
 public interface AccessPointService {
+    Long save(AccessPointRequest request);
 }

--- a/src/main/java/com/koreatech/hangill/service/AccessPointService.java
+++ b/src/main/java/com/koreatech/hangill/service/AccessPointService.java
@@ -1,0 +1,4 @@
+package com.koreatech.hangill.service;
+
+public interface AccessPointService {
+}

--- a/src/main/java/com/koreatech/hangill/service/BuildingManagingService.java
+++ b/src/main/java/com/koreatech/hangill/service/BuildingManagingService.java
@@ -12,9 +12,7 @@ public interface BuildingManagingService {
     void addNode(AddNodeToBuildingRequest request);
     void addEdge(AddEdgeToBuildingRequest request);
     Map<Long, List<Long[]>> findNumberGraph(Long id);
-
     void deleteEdge(Long buildingId, Long edgeId);
     void deleteNode(Long buildingId, Long nodeId);
-
     void deleteBuilding(Long buildingId);
 }

--- a/src/main/java/com/koreatech/hangill/service/NodeService.java
+++ b/src/main/java/com/koreatech/hangill/service/NodeService.java
@@ -1,0 +1,17 @@
+package com.koreatech.hangill.service;
+
+import com.koreatech.hangill.domain.Node;
+import com.koreatech.hangill.dto.NodeSearch;
+import com.koreatech.hangill.dto.request.BuildFingerprintRequest;
+import com.koreatech.hangill.dto.response.FingerprintResponse;
+
+import java.util.List;
+
+public interface NodeService {
+    void validateDuplicatedNode(NodeSearch nodeSearch);
+    void buildFingerPrint(BuildFingerprintRequest request);
+    Node findOne(NodeSearch nodeSearch);
+
+    List<FingerprintResponse> fingerprints(Long nodeId);
+
+}

--- a/src/main/java/com/koreatech/hangill/service/impl/AccessPointServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/AccessPointServiceImpl.java
@@ -1,0 +1,20 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.domain.AccessPoint;
+import com.koreatech.hangill.repository.AccessPointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AccessPointServiceImpl {
+    private final AccessPointRepository accessPointRepository;
+
+    public Long save(AccessPoint accessPoint) {
+        accessPointRepository.save(accessPoint);
+        return accessPoint.getId();
+    }
+
+}

--- a/src/main/java/com/koreatech/hangill/service/impl/AccessPointServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/AccessPointServiceImpl.java
@@ -1,7 +1,10 @@
 package com.koreatech.hangill.service.impl;
 
 import com.koreatech.hangill.domain.AccessPoint;
+import com.koreatech.hangill.dto.request.AccessPointRequest;
 import com.koreatech.hangill.repository.AccessPointRepository;
+import com.koreatech.hangill.repository.BuildingRepository;
+import com.koreatech.hangill.service.AccessPointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,12 +12,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class AccessPointServiceImpl {
+public class AccessPointServiceImpl implements AccessPointService {
     private final AccessPointRepository accessPointRepository;
+    private final BuildingRepository buildingRepository;
 
-    public Long save(AccessPoint accessPoint) {
+    @Transactional
+    public Long save(AccessPointRequest request) {
+        validateDuplicatedMac(request.getMac());
+        AccessPoint accessPoint = new AccessPoint(
+                request.getSsid(),
+                request.getMac(),
+                buildingRepository.findOne(request.getBuildingId())
+        );
         accessPointRepository.save(accessPoint);
         return accessPoint.getId();
     }
+
+    private void validateDuplicatedMac(String mac) {
+        if (accessPointRepository.findAll(mac).size() > 0) throw new IllegalArgumentException("동일 MAC 주소를 가진 AP가 존재!");
+    }
+
 
 }

--- a/src/main/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImpl.java
+++ b/src/main/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImpl.java
@@ -97,7 +97,9 @@ public class BuildingManagingServiceImpl implements BuildingManagingService {
 
     public void deleteEdge(Long buildingId, Long edgeId) {
         Building building = buildingRepository.findOne(buildingId);
-        building.getEdges().remove(edgeRepository.findOne(edgeId));
+        Edge edge = edgeRepository.findOne(edgeId);
+        if (edge == null) throw new IllegalArgumentException("해당 Id의 Edge가 없습니다!");
+        building.getEdges().remove(edge);
     }
 
     public void deleteNode(Long buildingId, Long nodeId) {

--- a/src/test/java/com/koreatech/hangill/Util/RequestFactory.java
+++ b/src/test/java/com/koreatech/hangill/Util/RequestFactory.java
@@ -1,0 +1,11 @@
+package com.koreatech.hangill.Util;
+
+
+import com.koreatech.hangill.dto.request.CreateBuildingRequest;
+
+public class RequestFactory {
+    public static CreateBuildingRequest createBuildingRequest(String name, String description) {
+        return new CreateBuildingRequest(name, description, null, null);
+    }
+
+}

--- a/src/test/java/com/koreatech/hangill/repository/AccessPointRepositoryTest.java
+++ b/src/test/java/com/koreatech/hangill/repository/AccessPointRepositoryTest.java
@@ -1,0 +1,23 @@
+package com.koreatech.hangill.repository;
+
+import com.koreatech.hangill.domain.AccessPoint;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+
+@SpringBootTest
+class AccessPointRepositoryTest {
+    @Autowired
+    AccessPointRepository accessPointRepository;
+    @Test
+    public void 조회쿼리_확인() throws Exception{
+        //given
+        //when
+        //then
+
+     }
+
+}

--- a/src/test/java/com/koreatech/hangill/service/impl/AccessPointServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/AccessPointServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.koreatech.hangill.service.impl;
+
+import com.koreatech.hangill.domain.AccessPoint;
+import com.koreatech.hangill.dto.request.AccessPointRequest;
+import com.koreatech.hangill.dto.request.CreateBuildingRequest;
+import com.koreatech.hangill.repository.AccessPointRepository;
+import com.koreatech.hangill.service.BuildingManagingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class AccessPointServiceImplTest {
+    @Autowired
+    AccessPointServiceImpl accessPointService;
+
+    @Autowired
+    AccessPointRepository accessPointRepository;
+
+    @Autowired
+    BuildingManagingService buildingManagingService;
+
+    @Test
+    public void AP_저장_테스트() throws Exception {
+        //given
+        CreateBuildingRequest request = new CreateBuildingRequest(
+                "2공학관", null, null, null
+        );
+        Long buildingId = buildingManagingService.saveBuilding(request);
+
+        AccessPointRequest accessPointRequest1 = createAPRequest("A", "A", buildingId);
+        AccessPointRequest accessPointRequest2 = createAPRequest("B", "B", buildingId);
+        AccessPointRequest accessPointRequest3 = createAPRequest("C", "C", buildingId);
+
+        //when
+        Long save1 = accessPointService.save(accessPointRequest1);
+        Long save2 = accessPointService.save(accessPointRequest2);
+        Long save3 = accessPointService.save(accessPointRequest3);
+
+        //then
+        AccessPoint ap1 = accessPointRepository.findOne(save1);
+        assertEquals(accessPointRequest1.getSsid(), ap1.getSsid(), "ssid 확인!");
+        assertEquals(accessPointRequest1.getMac(), ap1.getMac(), "MAC 확인!");
+        AccessPoint ap2 = accessPointRepository.findOne(save2);
+        assertEquals(accessPointRequest2.getSsid(), ap2.getSsid(), "ssid 확인!");
+        assertEquals(accessPointRequest2.getMac(), ap2.getMac(), "MAC 확인!");
+        AccessPoint ap3 = accessPointRepository.findOne(save3);
+        assertEquals(accessPointRequest3.getSsid(), ap3.getSsid(), "ssid 확인!");
+        assertEquals(accessPointRequest3.getMac(), ap3.getMac(), "MAC 확인!");
+
+        assertEquals(3, accessPointRepository.findAll(buildingId).size(), "공학 2관엔 3개의 AP가 있어야함");
+    }
+
+    private static AccessPointRequest createAPRequest(String ssid, String mac, long buildingId) {
+        AccessPointRequest accessPointRequest = new AccessPointRequest();
+        accessPointRequest.setSsid(ssid);
+        accessPointRequest.setMac(mac);
+        accessPointRequest.setBuildingId(buildingId);
+        return accessPointRequest;
+    }
+}

--- a/src/test/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImplTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -128,6 +127,8 @@ class BuildingManagingServiceImplTest {
         Long buildingId = buildingService.saveBuilding(
                 new CreateBuildingRequest("공학 2관", "컴공", null, null)
         );
+        em.flush();
+        em.clear();
         return buildingId;
     }
 
@@ -155,6 +156,9 @@ class BuildingManagingServiceImplTest {
                 buildingName,
                 "컴공", null, null
         ));
+
+        em.flush();
+        em.clear();
 
 
         buildingManagingService.addNode(

--- a/src/test/java/com/koreatech/hangill/service/impl/BuildingServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/BuildingServiceImplTest.java
@@ -10,6 +10,8 @@ import com.koreatech.hangill.dto.response.ShortestPathResponse;
 import com.koreatech.hangill.repository.BuildingRepository;
 import com.koreatech.hangill.repository.EdgeRepository;
 import com.koreatech.hangill.repository.NodeRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,6 +40,9 @@ class BuildingServiceImplTest {
 
     @Autowired
     EdgeRepository edgeRepository;
+
+    @PersistenceContext
+    EntityManager em;
 
 
     @Test
@@ -98,7 +103,7 @@ class BuildingServiceImplTest {
         ));
 
         //when
-        ShortestPathResponse shortestPathResponse = buildingService.dijkstra(new ShortestPathRequest(
+        ShortestPathResponse shortestPathResponse = buildingService.findPath(new ShortestPathRequest(
                 buildingId,
                 startNode.getId(), endNode.getId()
         ));
@@ -133,6 +138,7 @@ class BuildingServiceImplTest {
                 "공학2관",
                 "컴공", null, null
         ));
+
 
 
         buildingManagingService.addNode(

--- a/src/test/java/com/koreatech/hangill/service/impl/NodeServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/NodeServiceImplTest.java
@@ -1,42 +1,96 @@
 package com.koreatech.hangill.service.impl;
 
-import com.koreatech.hangill.dto.request.AddNodeToBuildingRequest;
-import com.koreatech.hangill.dto.request.CreateBuildingRequest;
-import com.koreatech.hangill.dto.request.CreateNodeRequest;
+import com.koreatech.hangill.domain.*;
+import com.koreatech.hangill.dto.request.*;
+import com.koreatech.hangill.repository.BuildingRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @SpringBootTest
 @Transactional
-@Rollback(value = false)
 class NodeServiceImplTest {
     @Autowired
     BuildingManagingServiceImpl buildingService;
     @Autowired
     NodeServiceImpl nodeService;
-    @Test
-    public void 건물에_노드_추가() throws Exception {
-        //given
-        Long buildingId = buildingService.saveBuilding(
-                new CreateBuildingRequest("공학 2관", "컴공", null, null)
-        );
 
-        CreateNodeRequest createNodeRequest = new CreateNodeRequest(1, null, null, null, 1);
-        CreateNodeRequest createNodeRequest2 = new CreateNodeRequest(2, null, null, null, 1);
-        CreateNodeRequest createNodeRequest3 = new CreateNodeRequest(3, null, null, null, 1);
+    @Autowired
+    BuildingRepository buildingRepository;
+
+    @Autowired
+    AccessPointServiceImpl accessPointService;
+
+//    @Rollback(value = false)
+    @Test
+    public void 핑거_프린트_구성() throws Exception {
+        //given
+        Long buildingId = buildingService.saveBuilding(new CreateBuildingRequest(
+                "공학 2관", "컴공 & 건디", null, null
+        ));
+        Building building = buildingRepository.findOne(buildingId);
+        // 2공에서 A, B, C 세가지 AP를 이용해 위치를 특정함
+        AccessPoint accessPointA = new AccessPoint("A", "A", building);
+        AccessPoint accessPointB = new AccessPoint("B", "B", building);
+        AccessPoint accessPointC = new AccessPoint("C", "C", building);
+        accessPointService.save(accessPointA);
+        accessPointService.save(accessPointB);
+        accessPointService.save(accessPointC);
+
+
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                new CreateNodeRequest(1, "1", "1", NodeType.ROAD, 1)
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                new CreateNodeRequest(2, "2", "2", NodeType.ROAD, 1)
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                new CreateNodeRequest(3, "3", "3", NodeType.ROAD, 1)
+        ));
+
+        Node node1 = building.getNodes().get(0);
+
+
+        BuildFingerprintRequest request1 = new BuildFingerprintRequest();
+        request1.setNodeId(node1.getId());
+        List<SignalRequest> signalRequests = new ArrayList<>();
+        // Node1에서 세 가지 신호가 잡힘
+        // A, B는 위치 특정 시 사용하는 신호
+        // D는 사용자 핫스팟과 같은 위치 특정시 사용하지 않는 신호
+        signalRequests.add(new SignalRequest("A", "A", -43)); // 건물에서 사용하는 AP 신호
+        signalRequests.add(new SignalRequest("B", "B", -77)); // 건물에서 사용하는 AP 신호
+        signalRequests.add(new SignalRequest("D", "D", -87)); // 건물에서 사용하지 않는 AP 신호
+        request1.setSignals(signalRequests);
+
 
 
         //when
-        nodeService.addNodeToBuilding(new AddNodeToBuildingRequest(buildingId, createNodeRequest));
-        nodeService.addNodeToBuilding(new AddNodeToBuildingRequest(buildingId, createNodeRequest2));
-        nodeService.addNodeToBuilding(new AddNodeToBuildingRequest(buildingId, createNodeRequest3));
+//        accessPointA.turnOff();
+        nodeService.buildFingerPrint(request1);
 
         //then
 
+        List<Fingerprint> fingerprints = node1.getFingerprints();
+        int rssiSum = 0;
+        for (Fingerprint fingerprint : fingerprints) {
+            System.out.println(fingerprint.getAccessPoint().getMac());
+            System.out.println(fingerprint.getAccessPoint().getSsid());
+            System.out.println(fingerprint.getRssi());
+            rssiSum += fingerprint.getRssi();
+        }
 
+        assertEquals(-120, rssiSum, "신호세기 합이 -120이어야함!!");
     }
+
+
 }

--- a/src/test/java/com/koreatech/hangill/service/impl/NodeServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/NodeServiceImplTest.java
@@ -2,6 +2,8 @@ package com.koreatech.hangill.service.impl;
 
 import com.koreatech.hangill.domain.*;
 import com.koreatech.hangill.dto.request.*;
+import com.koreatech.hangill.dto.response.FingerprintResponse;
+import com.koreatech.hangill.repository.AccessPointRepository;
 import com.koreatech.hangill.repository.BuildingRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +28,8 @@ class NodeServiceImplTest {
     BuildingRepository buildingRepository;
 
     @Autowired
+    AccessPointRepository accessPointRepository;
+    @Autowired
     AccessPointServiceImpl accessPointService;
 
 //    @Rollback(value = false)
@@ -40,9 +44,9 @@ class NodeServiceImplTest {
         AccessPoint accessPointA = new AccessPoint("A", "A", building);
         AccessPoint accessPointB = new AccessPoint("B", "B", building);
         AccessPoint accessPointC = new AccessPoint("C", "C", building);
-        accessPointService.save(accessPointA);
-        accessPointService.save(accessPointB);
-        accessPointService.save(accessPointC);
+        accessPointRepository.save(accessPointA);
+        accessPointRepository.save(accessPointB);
+        accessPointRepository.save(accessPointC);
 
 
         buildingService.addNode(new AddNodeToBuildingRequest(
@@ -81,15 +85,22 @@ class NodeServiceImplTest {
         //then
 
         List<Fingerprint> fingerprints = node1.getFingerprints();
+        List<FingerprintResponse> fingerprintResponses = nodeService.fingerprints(node1.getId());
         int rssiSum = 0;
-        for (Fingerprint fingerprint : fingerprints) {
-            System.out.println(fingerprint.getAccessPoint().getMac());
-            System.out.println(fingerprint.getAccessPoint().getSsid());
-            System.out.println(fingerprint.getRssi());
-            rssiSum += fingerprint.getRssi();
+        for (int i = 0; i < fingerprints.size(); i++) {
+            Fingerprint fp = fingerprints.get(i);
+            FingerprintResponse fpr = fingerprintResponses.get(i);
+            assertEquals(fp.getRssi(), fpr.getRssi());
+            assertEquals(fp.getAccessPoint().getSsid(), fpr.getSsid());
+            assertEquals(fp.getAccessPoint().getMac(), fpr.getMac());
+            rssiSum += fp.getRssi();
         }
 
         assertEquals(-120, rssiSum, "신호세기 합이 -120이어야함!!");
+
+
+
+
     }
 
 


### PR DESCRIPTION
## 추가 기능
실내 측위를 위한 기능을 추가하였음.
- Entity 추가
- AccessPoint 관리 기능
- Node에 Fingerprint 관리 기능
- Swagger 설정

## Entity 추가
- AccessPoint : 공유기 Entity
- Fingerprint : 노드에서 수신한 공유기의 신호세기(rssi)

## AccessPoint 관리 기능
- 건물에 AccessPoint 추가 기능
- 건물에 속한 AccessPoint 목록 조회 기능

## Node에 Fingerprint 관리 기능
- Node에서 수신한 rssi 목록을 이용하여 Fingerprint 목록을 생성하는 기능
- Node에 있는 Fingerprint 목록을 조회하는 기능

## Swagger 설정
- API 문서화.

## 추후 고려사항
- 측정한 rssi 목록을 이용해 특정 노드로 위치를 특정하는 API 설계
- ExceptionHandler를 이용한 Controller 예외처리
