### PR TITLE
feat : 건물 간선 삽입시 양방향으로 한번에 삽입되도록 수정

### DIFF
--- a/src/main/java/com/koreatech/hangill/controller/BuildingManagingController.java
+++ b/src/main/java/com/koreatech/hangill/controller/BuildingManagingController.java
@@ -59,8 +59,10 @@ public class BuildingManagingController implements BuildingManagingApi {
     @PostMapping("/api/v1/admin/building/edge")
     public ResponseEntity<Void> saveEdge(@Valid @RequestBody AddEdgeToBuildingRequest request) {
         buildingManagingService.addEdge(request);
+        // 양방향으로 추가
+        AddEdgeToBuildingRequest opposite = AddEdgeToBuildingRequest.oppositeEdge(request);
+        buildingManagingService.addEdge(opposite);
         return ResponseEntity.ok().build();
-
     }
 
     @GetMapping("/api/v1/admin/building/{buildingId}/graph")

--- a/src/main/java/com/koreatech/hangill/dto/request/AddEdgeToBuildingRequest.java
+++ b/src/main/java/com/koreatech/hangill/dto/request/AddEdgeToBuildingRequest.java
@@ -55,4 +55,15 @@ public class AddEdgeToBuildingRequest {
             example = "1021"
     )
     private Long distance;
+
+    public static AddEdgeToBuildingRequest oppositeEdge(AddEdgeToBuildingRequest request) {
+        return new AddEdgeToBuildingRequest(
+                request.getBuildingId(),
+                request.getEndNodeNumber(),
+                request.getEndNodeFloor(),
+                request.getStartNodeNumber(),
+                request.getStartNodeFloor(),
+                request.getDistance()
+        );
+    }
 }

--- a/src/test/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImplTest.java
+++ b/src/test/java/com/koreatech/hangill/service/impl/BuildingManagingServiceImplTest.java
@@ -42,6 +42,34 @@ class BuildingManagingServiceImplTest {
     NodeServiceImpl nodeService;
 
     @Test
+    public void 엣지_양방향_추가_테스트() throws Exception{
+        //given
+        Long buildingId = saveBuilding();
+
+        CreateNodeRequest createNodeRequest = new CreateNodeRequest(1, null, null, NodeType.ROAD, 1);
+        CreateNodeRequest createNodeRequest2 = new CreateNodeRequest(2, null, null, NodeType.ROAD, 1);
+        CreateNodeRequest createNodeRequest3 = new CreateNodeRequest(3, null, null, NodeType.ROAD, 1);
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                createNodeRequest
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                createNodeRequest2
+        ));
+        buildingService.addNode(new AddNodeToBuildingRequest(
+                buildingId,
+                createNodeRequest3
+        ));
+        //when
+        buildingService.addEdge(new AddEdgeToBuildingRequest(buildingId, 1, 1, 2, 1, 1000L));
+        buildingService.addEdge(new AddEdgeToBuildingRequest(buildingId, 1, 1, 3, 1, 1000L));
+
+        //then
+
+     }
+
+    @Test
     public void 건물에서_노드_추가() throws Exception {
         //given
         Long buildingId = saveBuilding();


### PR DESCRIPTION
- 간선 데이터가 많다보니 단방향 두번씩 넣기엔 매우 비효율적이다.
- 실 세계에 단방향 그래프는 거의 없으니, 양방향 그래프로 선택하기로 함.